### PR TITLE
Fix incremental sync bookmarking

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -223,6 +223,7 @@ class GithubClient:
             # Fetch the next page if next found in the response.
             if 'next' in r.links:
                 url = r.links['next']['url']
+                LOGGER.info(f'Found a next link: {url}')
             else:
             # Break the loop if all pages are fetched.
                 break

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -515,7 +515,7 @@ class IncrementalDateStream(Stream):
                             else:
                                 LOGGER.warning("Skipping this record for %s stream with %s = %s as it is missing replication key %s.",
                                             self.tap_stream_id, self.key_properties, record[self.key_properties], self.replication_keys)
-
+                if max_bookmark_value < start_date: max_bookmark_value = start_date
                 # Write bookmark for incremental stream.
                 self.write_bookmarks(self.tap_stream_id, selected_stream_ids, max_bookmark_value, repo_path, state)
                 singer.write_state(state) 

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -510,8 +510,8 @@ class IncrementalDateStream(Stream):
                                                                     stream_to_sync,
                                                                     selected_stream_ids,
                                                                     parent_record = record)
-                                # Write bookmark for incremental stream.
-                                self.write_bookmarks(self.tap_stream_id, selected_stream_ids, max_bookmark_value, repo_path, state)
+                                    # Write bookmark for incremental stream.
+                                    self.write_bookmarks(self.tap_stream_id, selected_stream_ids, max_bookmark_value, repo_path, state)
                             else:
                                 LOGGER.warning("Skipping this record for %s stream with %s = %s as it is missing replication key %s.",
                                             self.tap_stream_id, self.key_properties, record[self.key_properties], self.replication_keys)
@@ -647,7 +647,7 @@ class ReviewComments(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "updated_at"
     key_properties = ["id"]
-    additional_filters = f"sort=updated_at&direction=desc&per_page{PER_PAGE_NUMBER}"
+    additional_filters = f"sort=updated_at&direction=asc&per_page{PER_PAGE_NUMBER}"
     path = "pulls/{}/comments"
     use_repository = True
     id_keys = ['number']
@@ -691,7 +691,7 @@ class PullRequests(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "updated_at"
     key_properties = ["id"]
-    additional_filters = f"state=all&sort=updated&direction=desc&per_page{PER_PAGE_NUMBER}"
+    additional_filters = f"state=all&sort=updated&direction=asc&per_page{PER_PAGE_NUMBER}"
     path = "pulls"
     children = ['reviews', 'review_comments', 'pr_commits']
     has_children = True
@@ -892,7 +892,7 @@ class Comments(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "updated_at"
     key_properties = ["id"]
-    since_filter_param = f"&sort=updated&direction=desc&per_page={PER_PAGE_NUMBER}"
+    since_filter_param = f"&sort=updated&direction=asc&per_page={PER_PAGE_NUMBER}"
     path = "issues/comments"
 
 class Issues(IncrementalOrderedStream):
@@ -903,7 +903,7 @@ class Issues(IncrementalOrderedStream):
     replication_method = "INCREMENTAL"
     replication_keys = "updated_at"
     key_properties = ["id"]
-    since_filter_param = f"&state=all&sort=updated&direction=desc&per_page={PER_PAGE_NUMBER}"
+    since_filter_param = f"&state=all&sort=updated&direction=asc&per_page={PER_PAGE_NUMBER}"
     path = "issues"
     children = ["issue_assignees","issue_labels"]
     has_children = True

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -700,7 +700,7 @@ class Commits(IncrementalStream):
     path = "commits"
     children= ["commit_users_emails", "commit_files", "commit_parents", "commit_pull_request"]
     has_children = True
-    since_filter_param = f"&per_page={PER_PAGE_NUMBER}"
+    since_filter_param = f"&per_page=30"
 
     def add_fields_at_1st_level(self, record, parent_record = None):
         """

--- a/tap_github/sync.py
+++ b/tap_github/sync.py
@@ -206,7 +206,7 @@ def sync(client, config, state, catalog):
         for repo in get_ordered_repos(state, repositories):
             update_currently_syncing_repo(state, repo)
             LOGGER.info("Starting sync of repository: %s", repo)
-            do_sync(catalog, streams_to_sync_for_repos, selected_stream_ids, client, start_date, state, repo)
+            do_sync(catalog, streams_to_sync_for_repos, selected_stream_ids, client, start_date, state, repo, config)
 
             if client.not_accessible_repos:
                 # Give warning messages for a repo that is not accessible by a stream or is invalid.
@@ -215,14 +215,14 @@ def sync(client, config, state, catalog):
                 client.not_accessible_repos = set()
         update_currently_syncing_repo(state, None)
 
-def do_sync(catalog, streams_to_sync, selected_stream_ids, client, start_date, state, repo):
+def do_sync(catalog, streams_to_sync, selected_stream_ids, client, start_date, state, repo, config= {}):
     """
     Sync all other streams except teams, team_members and team_memberships for each repo.
     """
     currently_syncing = singer.get_currently_syncing(state)
     for stream_id in get_ordered_stream_list(currently_syncing, streams_to_sync):
         stream_obj = STREAMS[stream_id]()
-
+        LOGGER.info(f'Starting stream {stream_id} for {repo}.')
         # If it is a "sub_stream", it will be synced as part of the parent stream
         if stream_id in streams_to_sync and not stream_obj.parent:
             write_schemas(stream_id, catalog, selected_stream_ids)
@@ -234,7 +234,8 @@ def do_sync(catalog, streams_to_sync, selected_stream_ids, client, start_date, s
                                               repo_path = repo,
                                               start_date = start_date,
                                               selected_stream_ids = selected_stream_ids,
-                                              stream_to_sync = streams_to_sync
+                                              stream_to_sync = streams_to_sync,
+                                              config = config,
                                             )
 
             singer.write_state(state)


### PR DESCRIPTION
# Description of change
Changes made to the tap:
- Increase the request per_page size to control the number of requests made.
  - This has been changed from 30 (default) to 100 (maximum) on most tables
  - The only table that doesn't have 100 is commits, as this table has multiple children, and since we save a bookmark each time a request and all its children are completed, keeping track of the bookmark becomes difficult due to rate limit.
- Save a bookmark every time a request is made and processed, as opposed to only save it on the end.
- Change the direction of the ordered streams from Descending to Ascending in case of a rate limit error.
- Create a new type of stream where the fetching is done according to dates.
  - This will make the fetching less optimized, however it would be able to stop in the middle and resume on the next run, something the other types of streams can't do.
  - The data will be pulled from the API by a date_range, which can be configured, but it will be default to 7 days (requests would be like the following: 2021-01-01 - 2021-01-08)
  - We will save a bookmark for these types of streams (commits/workflow_runs) even if there are no records to be processed, so that we don't have to fetch from the start date every single time.